### PR TITLE
Bug fix on js/Text

### DIFF
--- a/src/lambdaisland/dom_types.cljs
+++ b/src/lambdaisland/dom_types.cljs
@@ -46,7 +46,7 @@
             (map hiccupize)
             (.-childNodes e)))))
 
-(register-printer js/Text js/Text #(.-data %))
+(register-printer js/Text 'js/Text #(.-data %))
 (register-printer js/Element 'js/Element hiccupize)
 (register-printer js/DocumentFragment 'js/DocumentFragment #(map hiccupize (.-children %)))
 (register-printer js/HTMLDocument 'js/HTMLDocument (fn [^js d] {:root (.-documentElement d)}))


### PR DESCRIPTION
The quote was forgotten.

Tested via the REPL in a browser via:
```
  (dom-types/register-printer js/Text 'js/Text #(.-data %))

  (let [text-node (-> js/document (.createTextNode "some text"))]
    (prn [(instance? js/Text text-node)
          text-node]))

  ;; It prints [true #js/Text "some text"]
```