### PR TITLE
Skip printing DOM elements without a defined `.-tagName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Fixed
 
+- Fixed printing DOM elements without a tag name.
+
 ## Changed
 
 # 0.0.19 (2021-08-09 / 293e461)

--- a/src/lambdaisland/dom_types.cljs
+++ b/src/lambdaisland/dom_types.cljs
@@ -36,15 +36,16 @@
     (string? e) e
     (instance? js/Text e) (.-data e)
     :else
-    (let [el [(keyword (str/lower-case (.-tagName e)))]]
-      (into (if-let [attrs (seq (.getAttributeNames e))]
-              (conj el (into {}
-                             (map (juxt csk/->kebab-case-keyword
-                                        #(truncate-attr (.getAttribute e %))))
-                             attrs))
-              el)
-            (map hiccupize)
-            (.-childNodes e)))))
+    (when-let [tag-name (.-tagName e)]
+      (let [el [(keyword (str/lower-case tag-name))]]
+        (into (if-let [attrs (seq (.getAttributeNames e))]
+                (conj el (into {}
+                               (map (juxt csk/->kebab-case-keyword
+                                          #(truncate-attr (.getAttribute e %))))
+                               attrs))
+                el)
+              (keep hiccupize)
+              (.-childNodes e))))))
 
 (register-printer js/Text 'js/Text #(.-data %))
 (register-printer js/Element 'js/Element hiccupize)


### PR DESCRIPTION
<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
Fixes #3 

Note: the `map` transducer was changed to the `keep` transducer to skip the nil value in the children.